### PR TITLE
feat: let the props type extend from `Intl.DateTimeFormatOptions`

### DIFF
--- a/src/runtime/components/NuxtTime.vue
+++ b/src/runtime/components/NuxtTime.vue
@@ -1,31 +1,12 @@
 <script setup lang='ts'>
 import { computed, getCurrentInstance, useHead } from '#imports'
 
-const props = defineProps<{
-  locale?: string
+interface NuxtTimeProps extends Intl.DateTimeFormatOptions {
+  locale?: string;
   datetime: string | number | Date
-  localeMatcher?: 'best fit' | 'lookup'
-  weekday?: 'long' | 'short' | 'narrow'
-  era?: 'long' | 'short' | 'narrow'
-  year?: 'numeric' | '2-digit'
-  month?: 'numeric' | '2-digit' | 'long' | 'short' | 'narrow'
-  day?: 'numeric' | '2-digit'
-  hour?: 'numeric' | '2-digit'
-  minute?: 'numeric' | '2-digit'
-  second?: 'numeric' | '2-digit'
-  timeZoneName?: 'short' | 'long' | 'shortOffset' | 'longOffset' | 'shortGeneric' | 'longGeneric'
-  formatMatcher?: 'best fit' | 'basic'
-  hour12?: boolean
-  timeZone?: string
+}
 
-  calendar?: string
-  dayPeriod?: 'narrow' | 'short' | 'long'
-  numberingSystem?: string
-
-  dateStyle?: 'full' | 'long' | 'medium' | 'short'
-  timeStyle?: 'full' | 'long' | 'medium' | 'short'
-  hourCycle?: 'h11' | 'h12' | 'h23' | 'h24'
-}>()
+const props = defineProps<NuxtTimeProps>()
 
 const renderedDate = getCurrentInstance()?.vnode.el?.getAttribute('datetime')
 const locale = getCurrentInstance()?.vnode.el?.getAttribute('locale')


### PR DESCRIPTION
Let the props type extend from `Intl.DateTimeFormatOptions`

**Before**
<https://github.com/danielroe/nuxt-time/blob/53d2b497616647ade3168784bbde1e9124369f24/src/runtime/components/NuxtTime.vue#L4-L28>

**After**

```ts
interface NuxtTimeProps extends Intl.DateTimeFormatOptions {
  locale?: string;
  datetime: string | number | Date
}

const props = defineProps<NuxtTimeProps>()
```
