### PR TITLE
fix: get the correct dataset attribute

### DIFF
--- a/src/runtime/components/NuxtTime.vue
+++ b/src/runtime/components/NuxtTime.vue
@@ -28,7 +28,7 @@ const props = defineProps<{
 }>()
 
 const renderedDate = getCurrentInstance()?.vnode.el?.getAttribute('datetime')
-const locale = getCurrentInstance()?.vnode.el?.getAttribute('locale')
+const locale = getCurrentInstance()?.vnode.el?.getAttribute('data-locale')
 
 const date = computed(() => {
   if (renderedDate) return new Date(renderedDate)


### PR DESCRIPTION
Resolve hydration error when server locale different when client side.

<img width="1152" alt="截圖 2023-02-11 下午7 13 46" src="https://user-images.githubusercontent.com/39984251/218255134-6d1a7824-3c37-4da2-9a5a-bbfb447b8d34.png">
