### PR TITLE
feat: allow time/locale to be updated after initial render

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,8 +1,3 @@
 export default defineNuxtConfig({
   modules: ['nuxt-time'],
-  vite: {
-    define: {
-      'process.test': 'true'
-    },
-  }
 })

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,7 +1,4 @@
 <script setup>
-if (process.client) {
-  await new Promise(resolve => setTimeout(resolve, process.test ? 0 : 500))
-}
 const locale = ref()
 const switchLocale = () => {
   locale.value = locale.value !== 'fr' ? 'fr' : 'en-GB'

--- a/src/runtime/components/NuxtTime.vue
+++ b/src/runtime/components/NuxtTime.vue
@@ -35,9 +35,10 @@ const locale = getCurrentInstance()?.vnode.el?.getAttribute('data-locale')
 const nuxtApp = useNuxtApp()
 
 const date = computed(() => {
-  if (renderedDate && !nuxtApp.isHydrated) return new Date(renderedDate)
+  const date = props.datetime
+  if (renderedDate && nuxtApp.isHydrating) return new Date(renderedDate)
   if (!props.datetime) return new Date()
-  return new Date(props.datetime)
+  return new Date(date)
 })
 
 const formatter = computed(() => {

--- a/src/runtime/components/NuxtTime.vue
+++ b/src/runtime/components/NuxtTime.vue
@@ -1,5 +1,5 @@
 <script setup lang='ts'>
-import { computed, getCurrentInstance, useHead } from '#imports'
+import { computed, getCurrentInstance, useNuxtApp, useHead } from '#imports'
 
 const props = withDefaults(defineProps<{
   locale?: string
@@ -32,8 +32,10 @@ const props = withDefaults(defineProps<{
 const renderedDate = getCurrentInstance()?.vnode.el?.getAttribute('datetime')
 const locale = getCurrentInstance()?.vnode.el?.getAttribute('data-locale')
 
+const nuxtApp = useNuxtApp()
+
 const date = computed(() => {
-  if (renderedDate) return new Date(renderedDate)
+  if (renderedDate && !nuxtApp.isHydrated) return new Date(renderedDate)
   if (!props.datetime) return new Date()
   return new Date(props.datetime)
 })

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -49,6 +49,7 @@ describe('nuxt-time', async () => {
     expect(await page.getByTestId('fixed').innerText()).toMatchInlineSnapshot('"11 février"')
 
     await page.getByText('Update time').click()
+    expect(await page.getByTestId('switchable').innerText()).not.toEqual('11 février à 8')
     expect(await page.getByTestId('fixed').innerText()).toMatchInlineSnapshot('"11 février"')
 
     // No hydration errors

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -37,11 +37,15 @@ describe('nuxt-time', async () => {
 
     await page.goto(url('/'), { waitUntil: 'networkidle' })
 
-    expect(await page.getByTestId('switchable').innerText()).toMatchInlineSnapshot('"11 February at 8"')
+    expect(await page.getByTestId('switchable').innerText()).toMatchInlineSnapshot(
+      '"11 February at 8"'
+    )
     expect(await page.getByTestId('fixed').innerText()).toMatchInlineSnapshot('"11 February"')
 
     await page.getByText('Switch locale').click()
-    expect(await page.getByTestId('switchable').innerText()).toMatchInlineSnapshot('"11 février à 8"')
+    expect(await page.getByTestId('switchable').innerText()).toMatchInlineSnapshot(
+      '"11 février à 8"'
+    )
     expect(await page.getByTestId('fixed').innerText()).toMatchInlineSnapshot('"11 février"')
 
     await page.getByText('Update time').click()

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -37,15 +37,15 @@ describe('nuxt-time', async () => {
 
     await page.goto(url('/'), { waitUntil: 'networkidle' })
 
-    // expect(await page.getByTestId('switchable').innerText()).toMatchInlineSnapshot('"11 February at 8"')
-    // expect(await page.getByTestId('fixed').innerText()).toMatchInlineSnapshot('"11 February"')
+    expect(await page.getByTestId('switchable').innerText()).toMatchInlineSnapshot('"11 February at 8"')
+    expect(await page.getByTestId('fixed').innerText()).toMatchInlineSnapshot('"11 February"')
 
-    // await page.getByText('Switch locale').click()
-    // expect(await page.getByTestId('switchable').innerText()).toMatchInlineSnapshot('"11 février à 8"')
-    // expect(await page.getByTestId('fixed').innerText()).toMatchInlineSnapshot('"11 février"')
+    await page.getByText('Switch locale').click()
+    expect(await page.getByTestId('switchable').innerText()).toMatchInlineSnapshot('"11 février à 8"')
+    expect(await page.getByTestId('fixed').innerText()).toMatchInlineSnapshot('"11 février"')
 
-    // await page.getByText('Update time').click()
-    // expect(await page.getByTestId('fixed').innerText()).toMatchInlineSnapshot('"11 février"')
+    await page.getByText('Update time').click()
+    expect(await page.getByTestId('fixed').innerText()).toMatchInlineSnapshot('"11 février"')
 
     // No hydration errors
     expect(logs.join('')).toMatchInlineSnapshot('""')


### PR DESCRIPTION
The aim is that the time component doesn't immediately update when hydrated, but only if a subsequent change to the time is detected, so `Date.now()` can be used in a server template and be 'frozen' at the time of render unless subsequently updated.

cc: @userquin 