### PR TITLE
refactor: reduce runtime size

### DIFF
--- a/src/runtime/components/NuxtTime.vue
+++ b/src/runtime/components/NuxtTime.vue
@@ -29,8 +29,9 @@ const props = withDefaults(defineProps<{
   hour12: undefined
 })
 
-const renderedDate = getCurrentInstance()?.vnode.el?.getAttribute('datetime')
-const locale = getCurrentInstance()?.vnode.el?.getAttribute('data-locale')
+const el = getCurrentInstance()?.vnode.el
+const renderedDate = el?.getAttribute('datetime')
+const locale = el?.getAttribute('data-locale')
 
 const nuxtApp = useNuxtApp()
 
@@ -42,27 +43,8 @@ const date = computed(() => {
 })
 
 const formatter = computed(() => {
-  return new Intl.DateTimeFormat(locale ?? props.locale, {
-    localeMatcher: props.localeMatcher,
-    weekday: props.weekday,
-    era: props.era,
-    year: props.year,
-    month: props.month,
-    day: props.day,
-    hour: props.hour,
-    minute: props.minute,
-    second: props.second,
-    timeZoneName: props.timeZoneName,
-    formatMatcher: props.formatMatcher,
-    hour12: props.hour12,
-    timeZone: props.timeZone,
-    calendar: props.calendar,
-    dayPeriod: props.dayPeriod,
-    numberingSystem: props.numberingSystem,
-    dateStyle: props.dateStyle,
-    timeStyle: props.timeStyle,
-    hourCycle: props.hourCycle,
-  })
+  const { locale: propsLocale, ...rest } = props
+  return new Intl.DateTimeFormat(locale ?? propsLocale, rest)
 })
 const formattedDate = computed(() => formatter.value.format(date.value))
 const isoDate = computed(() => date.value.toISOString())


### PR DESCRIPTION
Before

```
dist/runtime (total size: 3.11 kB)
└─ dist/runtime/components/NuxtTime.vue (3.11 kB)
```

After

```
dist/runtime (total size: 2.58 kB)
└─ dist/runtime/components/NuxtTime.vue (2.58 kB)
 ```