### PR TITLE
fix: handle camel-case options correctly

### DIFF
--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -17,6 +17,8 @@ const changeDate = () => {
     <br>
     <NuxtTime :locale="locale" data-testid="fixed" datetime="2023-02-11T08:24:08.396Z" month="long" day="numeric" />
     <br>
+    <NuxtTime datetime="2023-08-19T02:57:00.000Z" time-zone="America/New_York" />
+    <br />
     <button @click="switchLocale">Switch locale</button>
     <br>
     <button @click="changeDate">Update time</button>

--- a/src/runtime/components/NuxtTime.vue
+++ b/src/runtime/components/NuxtTime.vue
@@ -54,7 +54,8 @@ const dataset: Record<string, any> = {}
 if (process.server) {
   for (const prop in props) {
     if (prop !== 'datetime') {
-      dataset[`data-${prop}`] = props?.[prop as keyof typeof props]
+      const propInKebabCase = prop.split(/(?=[A-Z])/).join('-')
+      dataset[`data-${propInKebabCase}`] = props?.[prop as keyof typeof props]
     }
   }
   useHead({
@@ -63,11 +64,17 @@ if (process.server) {
       key: 'nuxt-time',
       innerHTML: `
         document.querySelectorAll('[data-n-time]').forEach(el => {
+          const toCamelCase = (name, index) => {
+            if (index > 0) { return name[0].toUpperCase() + name.slice(1) };
+            return name;
+          };
+
           const date = new Date(el.getAttribute('datetime'));
           const options = {};
           for (const name of el.getAttributeNames()) {
             if (name.startsWith('data-')) {
-              options[name.slice(5)] = el.getAttribute(name);
+              const optionName = name.slice(5).split('-').map(toCamelCase).join('');
+              options[optionName] = el.getAttribute(name);
             }
           }
 


### PR DESCRIPTION
Resolves https://github.com/danielroe/nuxt-time/issues/196

The Problem was that `Intl.DateTimeFormat` expects e.g. `timeZone`, but the current implementation passes e.g. `timezone` instead.

```js
// currently
new Intl.DateTimeFormat(options.locale, { timezone: 'America/New_York' });

// after fix
new Intl.DateTimeFormat(options.locale, { timeZone: 'America/New_York' });
```