### PR TITLE
feat: add optional title prop boolean or string

### DIFF
--- a/src/runtime/components/NuxtTime.vue
+++ b/src/runtime/components/NuxtTime.vue
@@ -26,6 +26,7 @@ const props = withDefaults(defineProps<{
   timeStyle?: 'full' | 'long' | 'medium' | 'short'
   hourCycle?: 'h11' | 'h12' | 'h23' | 'h24'
   relative?: boolean
+  title?: boolean | string
 }>(), {
   hour12: undefined,
 })
@@ -79,7 +80,7 @@ const formattedDate = computed(() => {
 })
 
 const isoDate = computed(() => date.value.toISOString())
-
+const title = computed(() => props.title === true ? isoDate.value : typeof props.title === 'string' ? props.title : undefined)
 const dataset: Record<string, string | number | boolean | Date | undefined> = {}
 
 if (import.meta.server) {
@@ -143,5 +144,6 @@ declare global {
   <time
     v-bind="dataset"
     :datetime="isoDate"
+    :title="title"
   >{{ formattedDate }}</time>
 </template>

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -39,4 +39,38 @@ describe('<NuxtTime>', () => {
       `"<time datetime="${new Date(datetime).toISOString()}">5 minutes ago</time>"`,
     )
   })
+
+  it('should display datetime in title', async () => {
+    const datetime = Date.now() - 5 * 60 * 1000
+    const thing = await mountSuspended(
+      defineComponent({
+        render: () =>
+          h(NuxtTime, {
+            datetime,
+            relative: true,
+            title: true,
+          }),
+      }),
+    )
+    expect(thing.html()).toMatchInlineSnapshot(
+      `"<time datetime="${new Date(datetime).toISOString()}" title="${new Date(datetime).toISOString()}">5 minutes ago</time>"`,
+    )
+  })
+
+  it('should display custom title', async () => {
+    const datetime = Date.now() - 5 * 60 * 1000
+    const thing = await mountSuspended(
+      defineComponent({
+        render: () =>
+          h(NuxtTime, {
+            datetime,
+            relative: true,
+            title: 'test',
+          }),
+      }),
+    )
+    expect(thing.html()).toMatchInlineSnapshot(
+      `"<time datetime="${new Date(datetime).toISOString()}" title="test">5 minutes ago</time>"`,
+    )
+  })
 })


### PR DESCRIPTION
Closes #311

- Optional title prop
- Accepts `boolean` or `string`
- Renders `isoDate` if `true`
- Renders custom value as usual if `string`
- Added tests